### PR TITLE
Add a command to npm install

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   node:
     image: node:latest
     working_dir: /app
+    command: npm install
     volumes:
       - .:/app
     expose:


### PR DESCRIPTION
@pmuens Then the user can just follow the README and just run `npm start`. Otherwise, it explodes.